### PR TITLE
CRITEO RTUS For prebid

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -60,6 +60,10 @@ export const spec = {
       if (tdid) {
         serverRequest.tdid = tdid;
       }
+      const criteoId = getId(request, 'criteoId');
+      if (criteoId) {
+        serverRequest.cri_prebid = criteoId;
+      }
       if (request.schain) {
         serverRequest.schain = JSON.stringify(request.schain);
       }

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -8,6 +8,7 @@ describe('YieldmoAdapter', function () {
   const ENDPOINT = 'https://ads.yieldmo.com/exchange/prebid';
 
   let tdid = '8d146286-91d4-4958-aff4-7e489dd1abd6';
+  let criteoId = 'aff4';
 
   let bid = {
     bidder: 'yieldmo',
@@ -178,6 +179,27 @@ describe('YieldmoAdapter', function () {
       };
       const data = spec.buildRequests([unifiedIdBid], bidderRequest).data;
       expect(data.tdid).to.deep.equal(tdid);
+    });
+
+    it('should add CRITEO RTUS id as parameter of request', function () {
+      const criteoIdBid = {
+        bidder: 'yieldmo',
+        params: {},
+        adUnitCode: 'adunit-code',
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250], [300, 600]]
+          }
+        },
+        bidId: '30b31c1838de1e',
+        bidderRequestId: '22edbae2733bf6',
+        auctionId: '1d1a030790a475',
+        userId: {
+          criteoId
+        }
+      };
+      const data = spec.buildRequests([criteoIdBid], bidderRequest).data;
+      expect(data.cri_prebid).to.deep.equal(criteoId);
     });
 
     it('should add gdpr information to request if available', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding support for CRITEO RTUS id to Yieldmo's prebid adapter. This integration will enable YIeldmo to use CRITEO RTUS ID to improve targeting for its clients.

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
