### PR TITLE
Yieldmo adapter: use POST instead of GET for banner requests

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -89,7 +89,7 @@ export const spec = {
       });
       serverRequest.p = '[' + serverRequest.p.toString() + ']';
       serverRequests.push({
-        method: 'GET',
+        method: 'POST',
         url: BANNER_SERVER_ENDPOINT,
         data: serverRequest
       });

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -153,10 +153,10 @@ describe('YieldmoAdapter', function () {
       utils.deepAccess(build(bidRequests, bidderReq), `${index}.data`) || {};
 
     describe('Banner:', function () {
-      it('should attempt to send banner bid requests to the endpoint via GET', function () {
+      it('should attempt to send banner bid requests to the endpoint via POST', function () {
         const requests = build([mockBannerBid()]);
         expect(requests.length).to.equal(1);
-        expect(requests[0].method).to.equal('GET');
+        expect(requests[0].method).to.equal('POST');
         expect(requests[0].url).to.be.equal(BANNER_ENDPOINT);
       });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Use POST HTTP method instead of GET for banner bid requests
