### PR TITLE
Yieldmo Bid Adapter: read video parameters from the ad unit

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -12,8 +12,8 @@ const NET_REVENUE = true;
 const BANNER_SERVER_ENDPOINT = 'https://ads.yieldmo.com/exchange/prebid';
 const VIDEO_SERVER_ENDPOINT = 'https://ads.yieldmo.com/exchange/prebidvideo';
 const OUTSTREAM_VIDEO_PLAYER_URL = 'https://prebid-outstream.yieldmo.com/bundle.js';
-const OPENRTB_VIDEO_BIDPARAMS = ['placement', 'startdelay', 'skipafter',
-  'protocols', 'api', 'playbackmethod', 'maxduration', 'minduration', 'pos'];
+const OPENRTB_VIDEO_BIDPARAMS = ['mimes', 'startdelay', 'placement', 'startdelay', 'skipafter', 'protocols', 'api',
+  'playbackmethod', 'maxduration', 'minduration', 'pos', 'skip', 'skippable'];
 const OPENRTB_VIDEO_SITEPARAMS = ['name', 'domain', 'cat', 'keywords'];
 const LOCAL_WINDOW = utils.getWindowTop();
 const DEFAULT_PLAYBACK_METHOD = 2;
@@ -335,7 +335,6 @@ function openRtbRequest(bidRequests, bidderRequest) {
  * @return Object OpenRTB's 'imp' (impression) object
  */
 function openRtbImpression(bidRequest) {
-  const videoReq = utils.deepAccess(bidRequest, 'mediaTypes.video');
   const size = extractPlayerSize(bidRequest);
   const imp = {
     id: bidRequest.bidId,
@@ -347,23 +346,27 @@ function openRtbImpression(bidRequest) {
     video: {
       w: size[0],
       h: size[1],
-      mimes: videoReq.mimes,
       linearity: 1
     }
   };
+
+  const mediaTypesParams = utils.deepAccess(bidRequest, 'mediaTypes.video');
+  Object.keys(mediaTypesParams)
+    .filter(param => includes(OPENRTB_VIDEO_BIDPARAMS, param))
+    .forEach(param => imp.video[param] = mediaTypesParams[param]);
 
   const videoParams = utils.deepAccess(bidRequest, 'params.video');
   Object.keys(videoParams)
     .filter(param => includes(OPENRTB_VIDEO_BIDPARAMS, param))
     .forEach(param => imp.video[param] = videoParams[param]);
 
-  if (videoParams.skippable) imp.video.skip = 1;
-  if (videoParams.placement !== 1) {
-    imp.video = {
-      ...imp.video,
-      startdelay: DEFAULT_START_DELAY,
-      playbackmethod: [ DEFAULT_PLAYBACK_METHOD ]
-    }
+  if (imp.video.skippable) {
+    imp.video.skip = 1;
+    delete imp.video.skippable;
+  }
+  if (imp.video.placement !== 1) {
+    imp.video.startdelay = DEFAULT_START_DELAY;
+    imp.video.playbackmethod = [ DEFAULT_PLAYBACK_METHOD ];
   }
   return imp;
 }
@@ -476,51 +479,68 @@ function validateVideoParams(bid) {
 
   const isDefined = val => typeof val !== 'undefined';
   const validate = (fieldPath, validateCb, errorCb, errorCbParam) => {
-    const value = utils.deepAccess(bid, fieldPath);
-    if (!validateCb(value)) {
-      errorCb(fieldPath, value, errorCbParam);
+    if (fieldPath.includes('video')) {
+      const valueFieldPath = 'params.' + fieldPath;
+      const mediaFieldPath = 'mediaTypes.' + fieldPath;
+      const valueParams = utils.deepAccess(bid, valueFieldPath);
+      const mediaTypesParams = utils.deepAccess(bid, mediaFieldPath);
+      const hasValidValueParams = validateCb(valueParams);
+      const hasValidMediaTypesParams = validateCb(mediaTypesParams);
+
+      if (hasValidValueParams) return valueParams;
+      else if (hasValidMediaTypesParams) return hasValidMediaTypesParams;
+      else {
+        if (!hasValidValueParams) errorCb(valueFieldPath, valueParams, errorCbParam);
+        else if (!hasValidMediaTypesParams) errorCb(mediaFieldPath, mediaTypesParams, errorCbParam);
+      }
+      return valueParams || mediaTypesParams;
+    } else {
+      const value = utils.deepAccess(bid, fieldPath);
+      if (!validateCb(value)) {
+        errorCb(fieldPath, value, errorCbParam);
+      }
+      return value;
     }
-    return value;
   }
 
   try {
+    validate('video.context', val => !utils.isEmpty(val), paramRequired);
+
     validate('params.placementId', val => !utils.isEmpty(val), paramRequired);
 
-    validate('mediaTypes.video.playerSize', val => utils.isArrayOfNums(val, 2) ||
+    validate('video.playerSize', val => utils.isArrayOfNums(val, 2) ||
       (utils.isArray(val) && val.every(v => utils.isArrayOfNums(v, 2))),
     paramInvalid, 'array of 2 integers, ex: [640,480] or [[640,480]]');
 
-    validate('mediaTypes.video.mimes', val => isDefined(val), paramRequired);
-    validate('mediaTypes.video.mimes', val => utils.isArray(val) && val.every(v => utils.isStr(v)), paramInvalid,
+    validate('video.mimes', val => isDefined(val), paramRequired);
+    validate('video.mimes', val => utils.isArray(val) && val.every(v => utils.isStr(v)), paramInvalid,
       'array of strings, ex: ["video/mp4"]');
 
-    validate('params.video', val => !utils.isEmpty(val), paramRequired);
-
-    const placement = validate('params.video.placement', val => isDefined(val), paramRequired);
-    validate('params.video.placement', val => val >= 1 && val <= 5, paramInvalid);
+    const placement = validate('video.placement', val => isDefined(val), paramRequired);
+    validate('video.placement', val => val >= 1 && val <= 5, paramInvalid);
     if (placement === 1) {
-      validate('params.video.startdelay', val => isDefined(val),
+      validate('video.startdelay', val => isDefined(val),
         (field, v) => paramRequired(field, v, 'placement == 1'));
-      validate('params.video.startdelay', val => utils.isNumber(val), paramInvalid, 'number, ex: 5');
+      validate('video.startdelay', val => utils.isNumber(val), paramInvalid, 'number, ex: 5');
     }
 
-    validate('params.video.protocols', val => isDefined(val), paramRequired);
-    validate('params.video.protocols', val => utils.isArrayOfNums(val) && val.every(v => (v >= 1 && v <= 6)),
+    validate('video.protocols', val => isDefined(val), paramRequired);
+    validate('video.protocols', val => utils.isArrayOfNums(val) && val.every(v => (v >= 1 && v <= 6)),
       paramInvalid, 'array of numbers, ex: [2,3]');
 
-    validate('params.video.api', val => isDefined(val), paramRequired);
-    validate('params.video.api', val => utils.isArrayOfNums(val) && val.every(v => (v >= 1 && v <= 6)),
+    validate('video.api', val => isDefined(val), paramRequired);
+    validate('video.api', val => utils.isArrayOfNums(val) && val.every(v => (v >= 1 && v <= 6)),
       paramInvalid, 'array of numbers, ex: [2,3]');
 
-    validate('params.video.playbackmethod', val => !isDefined(val) || utils.isArrayOfNums(val), paramInvalid,
+    validate('video.playbackmethod', val => !isDefined(val) || utils.isArrayOfNums(val), paramInvalid,
       'array of integers, ex: [2,6]');
 
-    validate('params.video.maxduration', val => isDefined(val), paramRequired);
-    validate('params.video.maxduration', val => utils.isInteger(val), paramInvalid);
-    validate('params.video.minduration', val => !isDefined(val) || utils.isNumber(val), paramInvalid);
-    validate('params.video.skippable', val => !isDefined(val) || utils.isBoolean(val), paramInvalid);
-    validate('params.video.skipafter', val => !isDefined(val) || utils.isNumber(val), paramInvalid);
-    validate('params.video.pos', val => !isDefined(val) || utils.isNumber(val), paramInvalid);
+    validate('video.maxduration', val => isDefined(val), paramRequired);
+    validate('video.maxduration', val => utils.isInteger(val), paramInvalid);
+    validate('video.minduration', val => !isDefined(val) || utils.isNumber(val), paramInvalid);
+    validate('video.skippable', val => !isDefined(val) || utils.isBoolean(val), paramInvalid);
+    validate('video.skipafter', val => !isDefined(val) || utils.isNumber(val), paramInvalid);
+    validate('video.pos', val => !isDefined(val) || utils.isNumber(val), paramInvalid);
     validate('params.badv', val => !isDefined(val) || utils.isArray(val), paramInvalid,
       'array of strings, ex: ["ford.com","pepsi.com"]');
     validate('params.bcat', val => !isDefined(val) || utils.isArray(val), paramInvalid,

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -479,7 +479,7 @@ function validateVideoParams(bid) {
 
   const isDefined = val => typeof val !== 'undefined';
   const validate = (fieldPath, validateCb, errorCb, errorCbParam) => {
-    if (fieldPath.includes('video')) {
+    if (fieldPath.indexOf('video') === 0) {
       const valueFieldPath = 'params.' + fieldPath;
       const mediaFieldPath = 'mediaTypes.' + fieldPath;
       const valueParams = utils.deepAccess(bid, valueFieldPath);

--- a/modules/yieldmoBidAdapter.md
+++ b/modules/yieldmoBidAdapter.md
@@ -96,3 +96,8 @@ var videoAdUnit = [{
   }]
 }];
 ```
+
+Please also note, that we support the following OpenRTB params: 
+'mimes', 'startdelay', 'placement', 'startdelay', 'skipafter', 'protocols', 'api',
+'playbackmethod', 'maxduration', 'minduration', 'pos', 'skip', 'skippable'.
+They can be specified in `mediaTypes.video` or in `bids[].params.video`.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer
- [ ] official adapter submission

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
