### PR TITLE
Yieldmo Bid Adapter: remove dead Topics handling (Chrome/Prebid killed Topics)

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -77,7 +77,6 @@ export const spec = {
     const videoBidRequests = bidRequests.filter(request => hasVideoMediaType(request));
     const serverRequests = [];
     const eids = getEids(bidRequests[0]) || [];
-    const topicsData = getTopics(bidderRequest);
     const cdep = getCdep(bidderRequest);
     if (bannerBidRequests.length > 0) {
       const serverRequest = {
@@ -99,9 +98,6 @@ export const spec = {
             deepAccess(bidderRequest, 'gppConsent.applicableSections') || []}),
         us_privacy: deepAccess(bidderRequest, 'uspConsent') || '',
       };
-      if (topicsData) {
-        serverRequest.topics = JSON.stringify(topicsData);
-      }
       const gpc = getGPCSignal(bidderRequest);
       if (gpc) {
         serverRequest.gpc = gpc;
@@ -173,9 +169,6 @@ export const spec = {
 
     if (videoBidRequests.length > 0) {
       const serverRequest = openRtbRequest(videoBidRequests, bidderRequest);
-      if (topicsData) {
-        serverRequest.topics = topicsData;
-      }
       if (eids.length) {
         deepSetValue(serverRequest, 'user.ext.eids', eids);
       };
@@ -442,25 +435,6 @@ function getGPCSignal(bidderRequest) {
 function getCdep(bidderRequest) {
   const cdep = deepAccess(bidderRequest, 'ortb2.device.ext.cdep') || null;
   return cdep;
-}
-
-function getTopics(bidderRequest) {
-  const userData = deepAccess(bidderRequest, 'ortb2.user.data') || [];
-  const topicsData = userData.filter((dataObj) => {
-    const segtax = dataObj.ext?.segtax;
-    return segtax >= 600 && segtax <= 609;
-  })[0];
-
-  if (topicsData) {
-    const topicsObject = {
-      taxonomy: topicsData.ext.segtax,
-      classifier: topicsData.ext.segclass,
-      // topics needs to be array of numbers
-      topics: Object.values(topicsData.segment).map(i => Number(i)),
-    };
-    return topicsObject;
-  }
-  return null;
 }
 
 /**

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -407,26 +407,6 @@ describe('YieldmoAdapter', function () {
         expect(placementInfo).to.include('"gpid":"/6355419/Travel/Europe/France/Paris"');
       });
 
-      it('should add topics to the banner bid request', function () {
-        const biddata = build([mockBannerBid()], mockBidderRequest({ortb2: { user: {
-          data: [
-            {
-              ext: {
-                segtax: 600,
-                segclass: '2206021246',
-              },
-              segment: ['7', '8', '9'],
-            },
-          ],
-        }}}));
-
-        expect(biddata[0].data.topics).to.equal(JSON.stringify({
-          taxonomy: 600,
-          classifier: '2206021246',
-          topics: [7, 8, 9],
-        }));
-      });
-
       it('should add cdep to the banner bid request', function () {
         const biddata = build(
           [mockBannerBid()],
@@ -712,33 +692,6 @@ describe('YieldmoAdapter', function () {
           }]
         };
         expect(buildAndGetData([mockVideoBid({...params})]).user.ext.eids).to.eql(params.fakeUserIdAsEids);
-      });
-
-      it('should add topics to the bid request', function () {
-        const videoBidder = mockBidderRequest(
-          {
-            ortb2: {
-              user: {
-                data: [
-                  {
-                    ext: {
-                      segtax: 600,
-                      segclass: '2206021246',
-                    },
-                    segment: ['7', '8', '9'],
-                  },
-                ],
-              },
-            },
-          },
-          [mockVideoBid()]
-        );
-        const payload = buildAndGetData([mockVideoBid()], 0, videoBidder);
-        expect(payload.topics).to.deep.equal({
-          taxonomy: 600,
-          classifier: '2206021246',
-          topics: [7, 8, 9],
-        });
       });
 
       it('should send gpc in the bid request', function () {


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Refactoring (removes dead code; no functional change on Prebid 11.26+)

## Description of change

Chrome removed the Privacy-Sandbox Topics API, and Prebid made `topicsFpdModule` a **no-op** as of **11.26** ([#15369](https://github.com/prebid/Prebid.js/pull/15369)) — `processFpd` now returns first-party data untouched and writes nothing to `ortb2.user.data`. The Yieldmo adapter's `getTopics` reads `ortb2.user.data` for `segtax` 600–609, so it now reads a signal that no longer exists.

This removes the dead topics handling:
- `getTopics()` and its call site
- the banner (`serverRequest.topics = JSON.stringify(...)`) and video (`serverRequest.topics = ...`) send-sites
- the two topics unit tests

It also eliminates a latent bug in that path: `getTopics` built the array with `Object.values(topicsData.segment).map(i => Number(i))`, but ORTB `user.data[].segment` is an array of `{ id }` objects, so `Number({id})` was `NaN` → the request sent `topics:[null,null,null]` whenever topics were present on Prebid < 11.26.

Surfaced during the **TDTN-8800** Prebid 9.53 → 11.x release audit.

## Testing
- `gulp test --file test/spec/modules/yieldmoBidAdapter_spec.js`: **67 passing**.
- `eslint` clean.

Refs TDTN-8800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
