### PR TITLE
Yieldmo Bid Adapter: do not bid on or sync COPPA (child-directed) requests

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -18,6 +18,7 @@ import {
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {Renderer} from '../src/Renderer.js';
+import {config} from '../src/config.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -70,6 +71,11 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (bidRequests, bidderRequest) {
+    // COPPA: Yieldmo does not serve child-directed inventory. When COPPA is set,
+    // discard the request at the adapter — send nothing so we never bid on it.
+    if (config.getConfig('coppa') === true) {
+      return [];
+    }
     const stage = isStage(bidderRequest);
     const bannerUrl = getAdserverUrl(BANNER_PATH, stage);
     const videoUrl = getAdserverUrl(VIDEO_PATH, stage);
@@ -212,6 +218,11 @@ export const spec = {
   },
 
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent = {}, uspConsent = '') {
+    // COPPA: Yieldmo does not serve or track child-directed inventory —
+    // suppress cookie-sync pixels on COPPA traffic, mirroring the bid discard.
+    if (config.getConfig('coppa') === true) {
+      return [];
+    }
     const syncs = [];
     const gdprFlag = `&gdpr=${gdprConsent.gdprApplies ? 1 : 0}`;
     const gdprString = `&gdpr_consent=${encodeURIComponent((gdprConsent.consentString || ''))}`;

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { spec } from 'modules/yieldmoBidAdapter.js';
 import * as utils from 'src/utils.js';
+import { config } from 'src/config.js';
 
 /* eslint no-console: ["error", { allow: ["log", "warn", "error"] }] */
 // above is used for debugging purposes only
@@ -462,6 +463,21 @@ describe('YieldmoAdapter', function () {
         expect(biddata[0].data.gpc).to.equal('1');
       });
 
+      it('should discard the banner request entirely when coppa is set', function () {
+        config.setConfig({ coppa: true });
+        try {
+          expect(build([mockBannerBid()])).to.deep.equal([]);
+        } finally {
+          config.resetConfig();
+        }
+      });
+
+      it('should build a normal banner request when coppa is not set', function () {
+        const requests = build([mockBannerBid()], mockBidderRequest());
+        expect(requests.length).to.equal(1);
+        expect(requests[0].url).to.equal(BANNER_ENDPOINT);
+      });
+
       it('should add eids to the banner bid request', function () {
         const params = {
           userIdAsEids: [{
@@ -758,6 +774,15 @@ describe('YieldmoAdapter', function () {
         expect(payload.regs.ext.gpc).to.equal('1');
       });
 
+      it('should discard the video request entirely when coppa is set', function () {
+        config.setConfig({ coppa: true });
+        try {
+          expect(build([mockVideoBid()], mockBidderRequest({}, [mockVideoBid()]))).to.deep.equal([]);
+        } finally {
+          config.resetConfig();
+        }
+      });
+
       it('should add device info to payload if available', function () {
         let videoBidder = mockBidderRequest({ ortb2: {
           device: {
@@ -945,6 +970,15 @@ describe('YieldmoAdapter', function () {
     });
     it('should register no syncs', function () {
       expect(spec.getUserSyncs({})).to.deep.equal([]);
+    });
+    it('should register no syncs on COPPA (child-directed) traffic', function () {
+      config.setConfig({ coppa: true });
+      try {
+        expect(spec.getUserSyncs({ iframeEnabled: true })).to.deep.equal([]);
+        expect(spec.getUserSyncs({ pixelEnabled: true })).to.deep.equal([]);
+      } finally {
+        config.resetConfig();
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

When a request is flagged **COPPA** (child-directed), `yieldmoBidAdapter` now **discards it at the adapter** — `buildRequests` returns no server request, so Yieldmo never bids on child-directed inventory. Previously the adapter forwarded no COPPA signal at all, so child-directed traffic went through unguarded on the prebid-js path.

This drops the traffic **client-side** rather than relying on the exchange to reject it — simpler, and independent of the adserving path.

Yieldmo internal ticket: **TDTN-8831** (COPPA portion).

## Changes (`modules/yieldmoBidAdapter.js`)

- **`buildRequests`**: early-return `[]` when `config.getConfig('coppa') === true`. This short-circuits before either the banner or video request is built, so both media types are covered by the single guard.
- **`getUserSyncs`**: early-return `[]` on the same `config.getConfig('coppa') === true` check, so no cookie-sync pixel is dropped on child-directed traffic either (matching the pattern in improvedigital / newspassid). Prebid core does not gate user syncs by COPPA, so the adapter does it.

COPPA is read consistently via `config.getConfig('coppa')` — the convention documented for adapters and used by the majority of bidders.

Together these ensure the adapter neither bids on nor sets identifiers for COPPA traffic.

## Testing

- `npx eslint modules/yieldmoBidAdapter.js test/spec/modules/yieldmoBidAdapter_spec.js` — clean (no output).
- `npx gulp test --file test/spec/modules/yieldmoBidAdapter_spec.js` — 73 passing. Tests: banner request discarded (`[]`) when coppa set, video request discarded when coppa set, normal banner request still built when coppa unset, and no user syncs registered when COPPA is on.

## Scope

- **Adapter-only and self-contained** — no exchange-side change is required for the prebid-js path, since the discard happens before any request leaves the browser. (The other integration paths — OpenRTB header / Prebid Server — already enforce COPPA exchange-side.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
